### PR TITLE
feat(download): add flag to avoid downloading existing images

### DIFF
--- a/docs/home.md
+++ b/docs/home.md
@@ -185,6 +185,8 @@ USAGE:
     fad [FLAGS] [OPTIONS] [SUBCOMMAND]
 
 FLAGS:
+    -u, --download-only-unexisting-in-folder    If true, it won't download the images that already exists in your
+                                                download folder. Useful to avoid huge git diffs
     -r, --force-file-extensions    If true, file extensions will prevail over naming convention (asset_name.jpg)
     -h, --help                     Prints help information
     -v, --opt-only-on-validation    If true, only new added images will be optimized. It's useful to only apply

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,12 +122,7 @@ async fn main() -> anyhow::Result<()> {
             if !cli.opt_only_on_validation {
                 for img_info in images_to_process {
                     let img = img_info.0;
-                    let path = if img.scale == 1 {
-                        download_path.to_owned()
-                    } else {
-                        download_path.join(format!("{}.0x", img.scale))
-                    };
-                    let final_path = path.join(format!("{}.{}", img.name.trim(), img.format));
+                    let final_path = img_info.1;
                     if let Err(e) = optimize_image(
                         &final_path,
                         &img.format,

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,7 +112,8 @@ async fn main() -> anyhow::Result<()> {
                 &images,
                 &download_path,
                 cli.download_only_unexisting_in_folder,
-            ).await;
+            )
+            .await;
 
             download_images(&images_to_process, &client)
                 .await
@@ -395,7 +396,7 @@ async fn get_images_info_to_process<'a>(
             download_path.join(format!("{}.0x", i.scale))
         };
         let final_path = path.join(format!("{}.{}", i.name.trim(), i.format));
-        
+
         if !download_only_unexisting_in_folder {
             images_to_process.push((i, final_path))
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,7 +112,7 @@ async fn main() -> anyhow::Result<()> {
                 &images,
                 &download_path,
                 cli.download_only_unexisting_in_folder,
-            );
+            ).await;
 
             download_images(&images_to_process, &client)
                 .await
@@ -382,7 +382,7 @@ fn to_images(frames: &[Node], urls: &ImageUrlCollection, scale: usize, format: &
         .collect()
 }
 
-fn get_images_info_to_process<'a>(
+async fn get_images_info_to_process<'a>(
     images: &'a [Image],
     download_path: &'a PathBuf,
     download_only_unexisting_in_folder: bool,
@@ -399,7 +399,7 @@ fn get_images_info_to_process<'a>(
         if !download_only_unexisting_in_folder {
             images_to_process.push((i, final_path))
         } else {
-            let file_exists = std::fs::metadata(&final_path).is_ok();
+            let file_exists = tokio::fs::metadata(&final_path).await.is_ok();
             if !file_exists {
                 images_to_process.push((i, final_path));
             }

--- a/src/models.rs
+++ b/src/models.rs
@@ -58,6 +58,10 @@ pub struct Cli {
     #[structopt(short = "v", long)]
     #[serde(default = "default_opt_only_on_validation")]
     pub opt_only_on_validation: bool,
+    /// If true, it won't download the images that already exists in your download folder. Useful to avoid huge git diffs.
+    #[structopt(short = "u", long)]
+    #[serde(default = "default_download_only_unexisting_in_folder")]
+    pub download_only_unexisting_in_folder: bool,
     #[structopt(subcommand)]
     pub subcommands: Option<SubCommands>,
 }
@@ -71,6 +75,9 @@ impl Cli {
         }
         if other_cli.force_file_extensions {
             self.force_file_extensions = true;
+        }
+        if other_cli.download_only_unexisting_in_folder {
+            self.download_only_unexisting_in_folder = true;
         }
         if other_cli.personal_access_token.is_some() {
             self.personal_access_token = other_cli.personal_access_token;
@@ -178,6 +185,10 @@ const fn default_force_file_extensions() -> bool {
 const fn default_opt_only_on_validation() -> bool {
     false
 }
+
+const fn default_download_only_unexisting_in_folder() -> bool {
+    false
+}
 // end of default values for serde
 
 #[derive(Debug, Deserialize, Clone)]
@@ -266,6 +277,7 @@ mod tests {
             file_scales: vec![1],
             file_extensions: vec![DEFAULT_FILE_EXT.to_owned()],
             force_file_extensions: false,
+            download_only_unexisting_in_folder: false,
             config_path: "".to_string(),
             opt_png_level: None,
             opt_jpg_level: None,
@@ -318,6 +330,19 @@ mod tests {
         cli.add_non_defaults(other);
 
         assert!(cli.force_file_extensions);
+    }
+
+    #[test]
+    fn cli_add_non_defaults_add_download_only_unexisting_in_folder_if_true() {
+        let mut cli = build_default_cli();
+        let mut other = build_default_cli();
+
+        assert!(!cli.download_only_unexisting_in_folder);
+
+        other.download_only_unexisting_in_folder = true;
+        cli.add_non_defaults(other);
+
+        assert!(cli.download_only_unexisting_in_folder);
     }
 
     #[test]


### PR DESCRIPTION
### Description:
Every time we run the fad tool it seems that the existing images get overwritten
with something that makes git count them as a new image.

### Solution:
Add a new flag (`-u`) and it's corresponding manifest flag
(`download_only_unexisting_in_folder`) to avoid overwritting the images
that we already have in the download folder.

Note that we don't check if there's a different version of each image,
we only check if the same image name exists.

Fixes: https://github.com/robertohuertasm/figma-asset-downloader/issues/18

CO-418