### PR TITLE
don't rely on rustc bug

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -262,7 +262,7 @@ async fn get_frames(
     }
 }
 
-async fn get_images<'a>(
+async fn get_images(
     frames: &Option<Frames>,
     client: &Client,
     file_id: &str,
@@ -304,7 +304,10 @@ async fn get_images<'a>(
 
         let mut futures = vec![];
 
-        let mut add_future_images = |image_ids: &'a str, format, scale| {
+        let mut add_future_images = |image_ids, format, scale| {
+            // hack: annotate type inside the closure to avoid rustc bug
+            let image_ids: &str = image_ids;
+
             if !image_ids.is_empty() {
                 futures.push(
                     get_images_url_collection(image_ids, client, file_id, scale, format)

--- a/src/main.rs
+++ b/src/main.rs
@@ -306,6 +306,7 @@ async fn get_images(
 
         let mut add_future_images = |image_ids, format, scale| {
             // hack: annotate type inside the closure to avoid rustc bug
+            // https://github.com/rust-lang/rust/issues/100002
             let image_ids: &str = image_ids;
 
             if !image_ids.is_empty() {


### PR DESCRIPTION
Hi,

https://github.com/rust-lang/rust/pull/98835 fixes a rustc bug that makes it incorrectly accepts the following code:
```rust
async fn test<'a>() { // 'a is longer than the entire function body
    let f = |_: &'a str| {}; // expects an argument that lives as long as 'a
    f(&String::new()); // the passed reference is shorter that `'a`
}
```

The crater run found that figma-asset-downloader relies on this bug. I'm not sure when this change reaches stable, if ever, but it's better to not rely on such a bug. This PR tries to fix this.

If you have an opinion on this change, please let me know here or  by commenting on the PR.

You can install and test the toolchain locally by running the command: `rustup-toolchain-install-master cb1f7c96119295882e08b09b4bd01051669c071b`

Edit: here is the error output when compiling `figma-asset-downloader`: https://crater-reports.s3.amazonaws.com/pr-98835/try%23cb1f7c96119295882e08b09b4bd01051669c071b/reg/figma-asset-downloader-0.9.0/log.txt